### PR TITLE
Pass relayTypes on to the relay pool

### DIFF
--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -218,6 +218,7 @@ class Nostr {
       onComplete: onComplete,
       tempRelays: tempRelays,
       targetRelays: targetRelays,
+      relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
     );
   }

--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -190,12 +190,19 @@ class Nostr {
     var eventBox = EventMemBox(sortAfterAdd: false);
     var completer = Completer();
 
-    query(filters, id: id, tempRelays: tempRelays, sendAfterAuth: sendAfterAuth,
-        (event) {
-      eventBox.add(event);
-    }, onComplete: () {
-      completer.complete();
-    });
+    query(
+      filters,
+      id: id,
+      tempRelays: tempRelays,
+      relayTypes: relayTypes,
+      sendAfterAuth: sendAfterAuth,
+      (event) {
+        eventBox.add(event);
+      },
+      onComplete: () {
+        completer.complete();
+      },
+    );
 
     await completer.future;
     return eventBox.all();


### PR DESCRIPTION
`relay types` were not being passed on to the relay pool. This means that, in the end, they were `RelayTypes.ALL` every time, even if I tried to set a specific `RelayType`. This change might impact SDK clients that are using this function, though.